### PR TITLE
added reset button to stop and move back to starting position

### DIFF
--- a/EV3DEV Python Simulator.url
+++ b/EV3DEV Python Simulator.url
@@ -1,0 +1,2 @@
+[InternetShortcut]
+URL=http://localhost:4242/

--- a/index.html
+++ b/index.html
@@ -50,6 +50,7 @@
           <div class="leftFlex">
             <button id="runCode">Run</button>
             <button id="stop">Stop</button>
+            <button id="reset">Reset</button>
           </div>
           <div class="center">
             <input type="checkbox" id="largeFont">Large Font
@@ -242,6 +243,15 @@ while True:
       document.getElementById('stop').addEventListener('click', function() {
         sim.stopAnimation();
         Sk.hardInterrupt = true;
+      });
+      document.getElementById('reset').addEventListener('click', function() {
+        sim.stopAnimation();
+        Sk.hardInterrupt = true;
+        setPos(
+          document.getElementById('xPos').value,
+          document.getElementById('yPos').value,
+          document.getElementById('angle').value
+        );
       });
       document.getElementById('largeFont').addEventListener('change', function(e) {
         if (e.target.checked) {

--- a/startHTTPServer.bat
+++ b/startHTTPServer.bat
@@ -1,0 +1,1 @@
+python -m http.server 4242


### PR DESCRIPTION
Figuring out this github thing...

Added a reset button that stops the sim and moves the robot back to the starting x and y.

Also added a bat file for starting the python webserver in windows in the directory as well as a shortcut to localhost to run the sim.

Would like to add a "Reset and run" button that stops the sim, moves the robot back to starting x and y, and starts the simulation again.  Not having luck.